### PR TITLE
chore: avoid nested error renders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Our tests are not thread-safe due to environment variable manipulation.
+  RUST_TEST_THREADS: 1
+
 jobs:
   # Only run first-party OIDC tests on events that don't come from forks,
   # since forks can't access the workflow's OIDC identity.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "ambient-id"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "reqwest",
  "reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ambient-id"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["William Woodruff <william@astral.sh>"]
 edition = "2024"
 description = "Detects ambient OIDC credentials in a variety of environments"

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ following environments:
 To run tests:
 
 ```sh
-cargo test
+RUST_TEST_THREADS=1 cargo test
 ```
+
+You **must** pass `RUST_TEST_THREADS=1` to ensure tests are run in a single
+thread, as this crate's tests manipulate environment variables and are not
+thread-safe.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,10 @@ impl IdToken {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An error occurred while detecting GitHub Actions credentials.
-    #[error("GitHub Actions detection error: {0}")]
+    #[error("GitHub Actions detection error")]
     GitHubActions(#[from] github::Error),
     /// An error occurred while detecting GitLab CI credentials.
-    #[error("GitLab CI detection error: {0}")]
+    #[error("GitLab CI detection error")]
     GitLabCI(#[from] gitlab::Error),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,14 +128,6 @@ impl Detector {
 mod tests {
     use crate::Detector;
 
-    /// A global lock to ensure only one test is manipulating
-    /// environment variables at a time.
-    ///
-    /// This effectively overrides Rust's default test parallelism,
-    /// but without the user needing to explicitly pass `--test-threads=1`
-    /// or `RUST_TEST_THREADS=1`.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// An environment variable delta.
     enum EnvDelta {
         /// Set an environment variable to a value.
@@ -149,20 +141,12 @@ mod tests {
     /// This maintains a stack of changes to unwind on drop; changes
     /// are unwound the reverse order of application
     pub(crate) struct EnvScope {
-        _guard: std::sync::MutexGuard<'static, ()>,
         changes: Vec<EnvDelta>,
     }
 
     impl EnvScope {
         pub fn new() -> Self {
-            // Hold the global environment lock for the duration of this scope.
-            // NOTE: This unwrap will panic if another test thread panics,
-            // e.g. due to an unexpected test failure.
-            let guard = ENV_LOCK.lock().unwrap();
-            EnvScope {
-                _guard: guard,
-                changes: vec![],
-            }
+            EnvScope { changes: vec![] }
         }
 
         /// Sets an environment variable for the duration of this scope.


### PR DESCRIPTION
Fixes a small cosmetic issue where we'd render these errors multiple times (once in the `#[error]`, and again via `#[from]`).