### PR TITLE
feat: expose detection error types

### DIFF
--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -1,16 +1,13 @@
+//! GitLab CI OIDC token detection.
+
 use crate::{DetectionState, DetectionStrategy};
 
+/// Possible errors during GitLab CI OIDC token detection.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// The expected environment variable for the ID token was not found.
+    #[error("ID token variable not found: {0}")]
     Missing(String),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::Missing(what) => write!(f, "ID token variable not found: {what}"),
-        }
-    }
 }
 
 pub(crate) struct GitLabCI;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@ use secrecy::{ExposeSecret, SecretString};
 mod github;
 mod gitlab;
 
+pub use github::Error as GitHubError;
+pub use gitlab::Error as GitLabError;
+
 /// A detected ID token.
 ///
 /// This is a newtype around a [`SecretString`] that ensures zero-on-drop
@@ -49,10 +52,10 @@ impl IdToken {
 pub enum Error {
     /// An error occurred while detecting GitHub Actions credentials.
     #[error("GitHub Actions detection error")]
-    GitHubActions(#[from] github::Error),
+    GitHubActions(#[from] GitHubError),
     /// An error occurred while detecting GitLab CI credentials.
     #[error("GitLab CI detection error")]
-    GitLabCI(#[from] gitlab::Error),
+    GitLabCI(#[from] GitLabError),
 }
 
 #[derive(Default)]


### PR DESCRIPTION
This exposes the error variants so that I can specialize error rendering in furtherance of https://github.com/astral-sh/uv/pull/15583.

I've also removed the manual `Display` impls, using `#[error]` is more idiomatic.