### PR TITLE
Support astral-reqwest-middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,8 +28,9 @@ dependencies = [
 
 [[package]]
 name = "ambient-id"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
+ "astral-reqwest-middleware",
  "reqwest",
  "reqwest-middleware",
  "secrecy",
@@ -54,6 +55,21 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "astral-reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 2.0.16",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ambient-id"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["William Woodruff <william@astral.sh>"]
 edition = "2024"
 description = "Detects ambient OIDC credentials in a variety of environments"
@@ -19,14 +19,16 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls-native-roots",
     "http2",
 ] }
-reqwest-middleware = "0.4.2"
+reqwest-middleware = { version = "0.4.2", optional = true }
+# Workaround for https://github.com/rust-lang/cargo/issues/9227#issuecomment-3532957795
+astral-reqwest-middleware = { version = "0.4.2", optional = true }
 secrecy = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 
 [features]
-default = []
+default = ["reqwest-middleware"]
 
 # This is a test-only feature to allow CI to run tests that require
 # a functional GitHub Actions OIDC environment (i.e. one provisioned


### PR DESCRIPTION
Workaround for https://github.com/rust-lang/cargo/issues/9227#issuecomment-3532957795 to allow publishing all our dependencies to crates.io.